### PR TITLE
Implement OSRM based routing

### DIFF
--- a/src/components/map/InteractiveMap.tsx
+++ b/src/components/map/InteractiveMap.tsx
@@ -109,14 +109,14 @@ const InteractiveMap: React.FC<InteractiveMapProps> = ({
 
     // Add route sources for each route
     routeResults.forEach((route) => {
-      // Simulate route geometry (in a real app, this would come from routing service)
-      const routeGeometry = generateRouteGeometry(startCoordinates, route.coordinates);
-      
+      const coordinates =
+        route.route?.coordinates || [[route.coordinates.lng, route.coordinates.lat]];
+
       map.current!.addSource(`route-${route.id}`, {
         type: 'geojson',
         data: {
           type: 'Feature',
-          properties: { 
+          properties: {
             routeId: route.id,
             color: route.color,
             distance: route.distance,
@@ -124,7 +124,7 @@ const InteractiveMap: React.FC<InteractiveMapProps> = ({
           },
           geometry: {
             type: 'LineString',
-            coordinates: routeGeometry
+            coordinates
           }
         }
       });


### PR DESCRIPTION
## Summary
- compute routes using OSRM in UltraModernStep2
- display loading indicator while routes are fetched
- draw real routes in InteractiveMap

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `cd backend && npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb0eeff2083288dc45f7955fe7b95