### PR TITLE
Add OSRM proxy and debug routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "proxy": "node proxy.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -67,7 +68,9 @@
     "xlsx": "^0.18.5",
     "zod": "^3.24.1",
     "zustand": "^5.0.5",
-    "axios": "^1.6.2"
+    "axios": "^1.6.2",
+    "express": "^4.19.2",
+    "request": "^2.88.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/proxy.js
+++ b/proxy.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const request = require('request');
+const app = express();
+const port = 3000;
+
+app.use((req, res, next) => {
+  res.header('Access-Control-Allow-Origin', '*');
+  next();
+});
+
+app.get('/route/:startLon/:startLat/:endLon/:endLat', (req, res) => {
+  const { startLon, startLat, endLon, endLat } = req.params;
+  const url = `https://router.project-osrm.org/route/v1/driving/${startLon},${startLat};${endLon},${endLat}?overview=full&geometries=geojson`;
+  req.pipe(request(url)).pipe(res);
+});
+
+app.listen(port, () => {
+  console.log(`Proxy läuft auf http://localhost:${port}`);
+});

--- a/src/components/map/InteractiveMap.tsx
+++ b/src/components/map/InteractiveMap.tsx
@@ -111,6 +111,34 @@ const InteractiveMap: React.FC<InteractiveMapProps> = ({
 
     console.log('🗺️ Setup Map Sources für', routeResults.length, 'Routen');
 
+    // Test-Linie hinzufügen
+    const testCoordinates = [
+      [startCoordinates.lng, startCoordinates.lat],
+      [9.2195, 48.7309]
+    ];
+
+    if (!map.current!.getSource('test-route')) {
+      map.current!.addSource('test-route', {
+        type: 'geojson',
+        data: {
+          type: 'Feature',
+          geometry: {
+            type: 'LineString',
+            coordinates: testCoordinates
+          }
+        }
+      });
+      map.current!.addLayer({
+        id: 'test-line',
+        type: 'line',
+        source: 'test-route',
+        paint: {
+          'line-color': '#ff0000',
+          'line-width': 5
+        }
+      });
+    }
+
     // Add route sources for each route
     routeResults.forEach((route) => {
       // Sicherstellen, dass die Route-ID gültig ist
@@ -119,8 +147,12 @@ const InteractiveMap: React.FC<InteractiveMapProps> = ({
         return;
       }
 
+      console.log('🗺️ Route-Koordinaten:', route.route?.coordinates);
       const coordinates =
-        route.route?.coordinates || [[route.coordinates.lng, route.coordinates.lat]];
+        route.route?.coordinates || [
+          [startCoordinates.lng, startCoordinates.lat],
+          [route.coordinates.lng, route.coordinates.lat]
+        ];
 
       console.log('🗺️ Adding route:', route.destinationName, 'with', coordinates.length, 'coordinates');
 

--- a/src/lib/services/routing-service.ts
+++ b/src/lib/services/routing-service.ts
@@ -22,8 +22,10 @@ class RoutingService {
   private readonly MAX_CACHE_SIZE = 100;
 
   private buildOSRMUrl(start: Coordinates, end: Coordinates, baseUrl?: string): string {
-    const base = baseUrl || this.OSRM_BASE_URL;
-    return `${base}/${start.lng},${start.lat};${end.lng},${end.lat}?overview=full&geometries=geojson`;
+    if (baseUrl) {
+      return `${baseUrl}/${start.lng},${start.lat};${end.lng},${end.lat}?overview=full&geometries=geojson`;
+    }
+    return `http://localhost:3000/route/${start.lng}/${start.lat}/${end.lng}/${end.lat}`;
   }
   
   // Alternative OSRM-Instanzen für Fallback


### PR DESCRIPTION
## Summary
- add Node.js proxy server to work around CORS
- adjust routing service to use local proxy when no baseUrl provided
- log route coordinates and provide fallback coordinates in map rendering
- insert a temporary test line on the map
- add helper script to start proxy and new dependencies

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ebc0b44908328aedd7391dce7c960