### PR TITLE
Unify station API path

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -101,17 +101,17 @@ GET    /api/auth/profile    # Geschützt, gibt User-Daten
 
 ### Polizeistationen (Öffentlich)
 ```http
-GET    /api/stations        # Alle Stationen (mit Filter)
-GET    /api/stations/:id    # Einzelne Station
+GET    /api/stationen        # Alle Stationen (mit Filter)
+GET    /api/stationen/:id    # Einzelne Station
 ```
 
 ### Polizeistationen (Admin-only)
 ```http
-POST   /api/stations        # Neue Station erstellen
-PUT    /api/stations/:id    # Station aktualisieren
-DELETE /api/stations/:id    # Station deaktivieren
-POST   /api/stations/bulk-import  # Bulk-Import
-GET    /api/stations/admin/stats  # Statistiken
+POST   /api/stationen        # Neue Station erstellen
+PUT    /api/stationen/:id    # Station aktualisieren
+DELETE /api/stationen/:id    # Station deaktivieren
+POST   /api/stationen/bulk-import  # Bulk-Import
+GET    /api/stationen/admin/stats  # Statistiken
 ```
 
 ### Custom-Adressen

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -72,7 +72,7 @@ app.get('/health', (req, res) => {
 
 // API routes
 app.use('/api/auth', authRoutes);
-app.use('/api/stations', stationsRoutes);
+app.use('/api/stationen', stationsRoutes);
 app.use('/api/addresses', addressesRoutes);
 app.use('/api/users', usersRoutes);
 app.use('/api/maps', mapsRoutes);

--- a/backend/src/routes/stations.ts
+++ b/backend/src/routes/stations.ts
@@ -10,7 +10,7 @@ const selectedPraesidien = new Set<string>();
 const autoSelectedReviere = new Set<string>();
 const manuallySelectedReviere = new Set<string>();
 
-// GET /api/stations - Public endpoint
+// GET /api/stationen - Public endpoint
 router.get('/', async (req, res) => {
   try {
     const { 
@@ -66,7 +66,7 @@ router.get('/', async (req, res) => {
   }
 });
 
-// GET /api/stations/:id - Public endpoint
+// GET /api/stationen/:id - Public endpoint
 router.get('/:id', async (req, res) => {
   try {
     const { id } = req.params;
@@ -86,7 +86,7 @@ router.get('/:id', async (req, res) => {
   }
 });
 
-// POST /api/stations - Admin only
+// POST /api/stationen - Admin only
 router.post('/', 
   authenticateToken, 
   requireAdmin, 
@@ -112,7 +112,7 @@ router.post('/',
   }
 );
 
-// PUT /api/stations/:id - Admin only
+// PUT /api/stationen/:id - Admin only
 router.put('/:id', 
   authenticateToken, 
   requireAdmin,
@@ -148,7 +148,7 @@ router.put('/:id',
   }
 );
 
-// DELETE /api/stations/:id - Admin only (Soft delete)
+// DELETE /api/stationen/:id - Admin only (Soft delete)
 router.delete('/:id', 
   authenticateToken, 
   requireAdmin,
@@ -183,7 +183,7 @@ router.delete('/:id',
   }
 );
 
-// POST /api/stations/bulk-import - Admin only
+// POST /api/stationen/bulk-import - Admin only
 router.post('/bulk-import',
   authenticateToken,
   requireAdmin,
@@ -234,7 +234,7 @@ router.post('/bulk-import',
   }
 );
 
-// GET /api/stations/hierarchical - Public
+// GET /api/stationen/hierarchical - Public
 router.get('/hierarchical', async (req, res) => {
   try {
     const praesidien = await prisma.policeStation.findMany({
@@ -248,7 +248,7 @@ router.get('/hierarchical', async (req, res) => {
   }
 });
 
-// GET /api/stations/praesidien - Public
+// GET /api/stationen/praesidien - Public
 router.get('/praesidien', async (_req, res) => {
   try {
     const praesidien = await prisma.policeStation.findMany({
@@ -261,7 +261,7 @@ router.get('/praesidien', async (_req, res) => {
   }
 });
 
-// GET /api/stations/praesidien/:id/revier - Public
+// GET /api/stationen/praesidien/:id/revier - Public
 router.get('/praesidien/:id/revier', async (req, res) => {
   try {
     const { id } = req.params;
@@ -275,7 +275,7 @@ router.get('/praesidien/:id/revier', async (req, res) => {
   }
 });
 
-// POST /api/stations/selection - Selection logic
+// POST /api/stationen/selection - Selection logic
 router.post('/selection', async (req, res) => {
   const { action, praesidiumId, revierId } = req.body;
 
@@ -315,7 +315,7 @@ router.post('/selection', async (req, res) => {
   }
 });
 
-// GET /api/stations/stats - Admin only
+// GET /api/stationen/stats - Admin only
 router.get('/admin/stats', authenticateToken, requireAdmin, async (req, res) => {
   try {
     const [

--- a/backend/tests/stations.test.ts
+++ b/backend/tests/stations.test.ts
@@ -13,13 +13,13 @@ jest.mock('../src/lib/prisma', () => ({
 describe('Station routes', () => {
   const { prisma } = require('../src/lib/prisma');
 
-  test('GET /api/stations returns stations array', async () => {
+  test('GET /api/stationen returns stations array', async () => {
     (prisma.policeStation.findMany as jest.Mock).mockResolvedValue([
       { id: '1', name: 'Station 1' },
     ]);
     (prisma.policeStation.count as jest.Mock).mockResolvedValue(1);
 
-    const res = await request(app).get('/api/stations');
+    const res = await request(app).get('/api/stationen');
 
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body.stations)).toBe(true);


### PR DESCRIPTION
## Summary
- switch backend route prefix to `/api/stationen`
- update station route docs and comments
- adjust corresponding Jest tests

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8c6be1fc8328afc37499682beeef