### PR TITLE
Fix CORS options

### DIFF
--- a/backend/simple-server.js
+++ b/backend/simple-server.js
@@ -10,16 +10,9 @@ app.set('trust proxy', 1);
 
 // CORS konfigurieren - dynamisch alle localhost Ports erlauben (für Entwicklung)
 const corsOptions = {
-  origin: (origin, callback) => {
-    // Erlaubt alle localhost Origins
-    if (!origin || origin.startsWith('http://localhost:')) {
-      callback(null, true);
-    } else {
-      callback(new Error('Not allowed by CORS'));
-    }
-  },
+  origin: 'http://localhost:5175',
+  methods: ['GET', 'POST', 'PUT', 'DELETE'],
   credentials: true,
-  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization']
 };
 


### PR DESCRIPTION
## Summary
- narrow CORS configuration for the simple server

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in backend *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f97aa03f48328ac2f47b385b232b0