### PR TITLE
Fix station management save data

### DIFF
--- a/src/components/admin/AdminStationManagement.tsx
+++ b/src/components/admin/AdminStationManagement.tsx
@@ -403,12 +403,36 @@ const AdminStationManagement: React.FC = () => {
     filteredStations.filter(s => s.type === 'revier' && s.parentId === praesidiumId)
 
   const handleSave = async (formData: Partial<Station>) => {
+    const {
+      name,
+      type,
+      city,
+      address,
+      coordinates,
+      telefon,
+      email,
+      notdienst24h,
+      isActive,
+    } = formData
+
+    const newStationData = {
+      name,
+      type,
+      city,
+      address,
+      coordinates,
+      telefon,
+      email,
+      notdienst24h,
+      isActive,
+    }
+
     try {
       if (editingStation) {
-        await updateStation(editingStation.id, formData)
+        await updateStation(editingStation.id, newStationData)
         toast.success('Station erfolgreich aktualisiert')
       } else {
-        await createStation(formData as Station)
+        await createStation(newStationData as Station)
         toast.success('Station erfolgreich erstellt')
       }
       setEditingStation(null)


### PR DESCRIPTION
## Summary
- ensure modal's save function only sends necessary data to API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f97ad82d08328b9452c3612872549