### PR TITLE
Fix undefined allCities in StationModal

### DIFF
--- a/src/components/admin/AdminStationManagement.tsx
+++ b/src/components/admin/AdminStationManagement.tsx
@@ -114,7 +114,18 @@ const StationCard: React.FC<StationCardProps> = ({ station, onEdit, onDelete, is
 }
 
 // Modern Modal Component
-const StationModal = ({ station, isOpen, onClose, onSave, isLoading, error, showInactive, searchTerm, cityFilter }) => {
+const StationModal = ({
+  station,
+  isOpen,
+  onClose,
+  onSave,
+  isLoading,
+  error,
+  showInactive,
+  searchTerm,
+  cityFilter,
+  allCities,
+}) => {
   const { stations } = useAdminStore();
   const [formData, setFormData] = useState({
     name: '',
@@ -424,6 +435,7 @@ const StationModal = ({ station, isOpen, onClose, onSave, isLoading, error, show
         showInactive={showInactive}
         searchTerm={searchTerm}
         cityFilter={cityFilter}
+        allCities={allCities}
       />
     </div>
   )
@@ -725,6 +737,7 @@ const AdminStationManagement: React.FC = () => {
         showInactive={showInactive}
         searchTerm={searchTerm}
         cityFilter={cityFilter}
+        allCities={allCities}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- allow passing a list of cities to `StationModal`
- include `allCities` when invoking `StationModal`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685fba10f8588328bf6d4ba4ecee7c79